### PR TITLE
CLI-001 jest refactor for temp DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,79 @@ A minimalist TypeScript CLI tool for manually tracking financial transactions.
 git clone https://github.com/patrick-s-young/banking-cli
 cd bankbook-cli
 npm install
+
+Sure! Here's a `README.md` template for your CLI project using the format you specified:
+
+---
+
+# JSON Filter CLI
+
+## Description
+
+`json-filter` is a command-line tool for filtering and querying JSON files using simple CLI arguments. It supports filtering by key-value pairs, partial matches, and date ranges. This tool is especially useful for developers and data analysts who want to quickly extract subsets of JSON data without writing custom scripts.
+
+## Installation
+
+1. Clone the repository:
+
+   ```bash
+   git clone https://github.com/your-username/json-filter.git
+   cd json-filter
+   ```
+
+2. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+3. (Optional) Link globally for easier use:
+
+   ```bash
+   npm link
+   ```
+
+## Development and Testing
+
+### Prerequisites
+
+* Node.js (version 18+ recommended)
+* npm
+
+### Local Setup
+
+To run the CLI locally without linking:
+
+```bash
+npx tsx src/index.ts --help
+```
+
+Or run it via a script defined in `package.json`:
+
+```bash
+npm run start -- --help
+```
+
+### Running Automated Tests
+
+1. Make sure all dependencies are installed:
+
+   ```bash
+   npm install
+   ```
+
+2. Run tests using:
+
+   ```bash
+   npm test
+   ```
+
+3. The test suite uses Jest and includes unit tests for key CLI functions like parsing arguments, applying filters, and reading/writing files.
+
+## License
+
+This project is licensed under the MIT License. See the [LICENSE](./LICENSE) file for details.
+
+---
+
+Let me know if you'd like the README to reflect any specific commands or example usage from your actual implementation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,13 @@
       "dependencies": {
         "@types/node": "^24.0.11",
         "commander": "^14.0.0",
+        "cross-env": "^7.0.3",
         "ts-node": "^10.9.2",
         "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
+        "dotenv": "^17.2.0",
         "jest": "^30.0.4",
         "ts-jest": "^29.4.0",
         "typescript": "^5.8.3"
@@ -2090,11 +2092,28 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "license": "MIT"
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2165,6 +2184,19 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.0.tgz",
+      "integrity": "sha512-Q4sgBT60gzd0BB0lSyYD3xM4YxrXA9y4uBDof1JNYGzOXrQdQ6yX+7XIAqoFOGQFOTK1D3Hts5OllpxMDZFONQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/eastasianwidth": {
@@ -2627,7 +2659,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -3791,7 +3822,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3963,7 +3993,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -3976,7 +4005,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4628,7 +4656,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
-  "name": "logfilter-cli",
+  "name": "banking-cli",
   "version": "1.0.0",
   "main": "dist/index.ts",
   "type": "commonjs",
+  "bin": {
+    "banking-cli": "./dist/cli.js"
+  },
   "scripts": {
     "test": "jest",
     "build": "tsc",

--- a/src/commands/get.ts
+++ b/src/commands/get.ts
@@ -1,12 +1,15 @@
 import { findTransactionById } from '../store'
 
 export async function getTransaction(id: string) {
-  const tx = await findTransactionById(id)
-  if (!tx) throw new Error(`No transaction found with ID ${id}`)
-  return `
-Transaction ${tx.id}
-  Account: ${tx.accountName}
-  Date:    ${tx.date}
-  Amount:  $${tx.amount.toFixed(2)}
-`.trim()
+    const tx = await findTransactionById(id)
+    if (!tx) {
+      throw new Error(`No transaction found with ID ${id}`)
+    }
+    return `
+      Transaction ${tx.id}
+        Account: ${tx.accountName}
+        Date:    ${tx.date}
+        Amount:  $${tx.amount.toFixed(2)}
+      `.trim()
+
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,0 @@
-
-
-export let FILE_PATH = 'transactions.json'
-
-export function setFilePath(path: string) {
-  FILE_PATH = path
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,22 @@
-#!/usr/bin/env ts-node
 
 import { Command } from 'commander'
 import { addTransaction } from './commands/add'
 import { getTransaction } from './commands/get'
 import { getBalance } from './commands/balance'
+import path from 'path'
 
+process.env.DB_PATH = path.join(__dirname, 'transaction.json')
 const program = new Command()
 
 program
-  .name('bankbook')
+  .name('banking-cli')
   .description('Manual financial transaction tracker')
   .version('1.0.0')
 
 program
   .command('add')
-  .description('Add a transaction')
-  .argument('<keyValuePairs>', 'Comma-separated key=value list: accountName,amount,date')
+  .description('Add a transaction (e.g., add "accountName=$string,amount=$number,date=$date")')
+  .argument('<keyValuePairs>', 'Comma-separated key=value list: accountName,amount,date example:"accountName=savings,amount=120,date=07-15-2025"')
   .action(async (input: string) => {
     try {
       const id = await addTransaction(input)

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,20 +1,28 @@
 import fs from 'fs/promises'
 import { Transaction } from './types'
-import { FILE_PATH } from './config'
 
 export async function loadTransactions(): Promise<Transaction[]> {
+  const DB_PATH = process.env.DB_PATH as string
   try {
-    const content = await fs.readFile(FILE_PATH, 'utf8')
+    const content = await fs.readFile(DB_PATH, 'utf8')
     return JSON.parse(content)
-  } catch {
-    return []
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('ENOENT')) {
+      return []
+    }
+    throw err
   }
 }
 
-export async function saveTransaction(tx: Transaction): Promise<void> {
+export async function saveTransaction(tx: Transaction): Promise<void> {  
+  const DB_PATH = process.env.DB_PATH as string
   const transactions = await loadTransactions()
   transactions.push(tx)
-  await fs.writeFile(FILE_PATH, JSON.stringify(transactions, null, 2))
+  try {
+    await fs.writeFile(DB_PATH, JSON.stringify(transactions, null, 2))
+  } catch (err) {
+    throw err
+  }
 }
 
 export async function findTransactionById(id: string): Promise<Transaction | undefined> {

--- a/src/tests/add.test.ts
+++ b/src/tests/add.test.ts
@@ -1,21 +1,19 @@
 import { addTransaction } from '../commands/add'
 import fs from 'fs/promises'
-import { setFilePath } from '../config'
+import { createTempDb } from './setUpTestDb'
 
-const TEST_DB_PATH = 'transactions.test.json'
-setFilePath(TEST_DB_PATH)
+let DB_PATH: string
 
 beforeEach(async () => {
-  await fs.writeFile(TEST_DB_PATH, '[]', 'utf-8')
+  DB_PATH = await createTempDb()
+  process.env.DB_PATH = DB_PATH
 })
 
 test('adds a valid transaction and stores it correctly', async () => {
   const input = 'accountName=test,amount=123.45,date=2025-07-10'
   const id = await addTransaction(input)
-
-  const content = await fs.readFile(TEST_DB_PATH, 'utf-8')
+  const content = await fs.readFile(DB_PATH, 'utf-8')
   const txs = JSON.parse(content)
-
   const match = txs.find((t: any) => t.id === id)
 
   expect(match).toBeDefined()
@@ -26,6 +24,8 @@ test('adds a valid transaction and stores it correctly', async () => {
 
 afterAll(async () => {
   try {
-    await fs.unlink(TEST_DB_PATH)
-  } catch {}
+    await fs.unlink(DB_PATH)
+  } catch {
+    // no file to delete
+  }
 })

--- a/src/tests/balance.test.ts
+++ b/src/tests/balance.test.ts
@@ -1,22 +1,20 @@
 import { addTransaction } from '../commands/add'
 import { getBalance } from '../commands/balance'
 import fs from 'fs/promises'
-import { setFilePath } from '../config'
+import { createTempDb } from './setUpTestDb'
 
-const TEST_DB_PATH = 'transactions.test.json'
-setFilePath(TEST_DB_PATH)
+let DB_PATH: string
 
 beforeEach(async () => {
-  await fs.writeFile(TEST_DB_PATH, '[]', 'utf-8')
+  DB_PATH = await createTempDb()
+  process.env.DB_PATH = DB_PATH
 })
 
 test('computes balance correctly for a single account', async () => {
   await addTransaction('accountName=savings,amount=200.00,date=2025-07-10')
   await addTransaction('accountName=savings,amount=-50.00,date=2025-07-11')
   await addTransaction('accountName=savings,amount=25.00,date=2025-07-12')
-
   const balance = await getBalance('savings')
-
   expect(balance).toBe('Balance for "savings": $175.00')
 })
 
@@ -28,15 +26,14 @@ test('returns $0.00 for account with no transactions', async () => {
 test('ignores transactions from other accounts', async () => {
   await addTransaction('accountName=main,amount=100.00,date=2025-07-10')
   await addTransaction('accountName=extra,amount=999.99,date=2025-07-10')
-
   const balance = await getBalance('main')
   expect(balance).toBe('Balance for "main": $100.00')
 })
 
 afterAll(async () => {
   try {
-    await fs.unlink(TEST_DB_PATH)
+    await fs.unlink(DB_PATH)
   } catch {
-    // - ignore if file doesn't exist
+    // no file to delete
   }
 })

--- a/src/tests/get.test.ts
+++ b/src/tests/get.test.ts
@@ -1,19 +1,18 @@
 import { addTransaction } from '../commands/add'
 import { getTransaction } from '../commands/get'
 import fs from 'fs/promises'
-import { setFilePath } from '../config'
+import { createTempDb } from './setUpTestDb'
 
-const TEST_DB_PATH = 'transactions.test.json'
-setFilePath(TEST_DB_PATH)
+let DB_PATH: string
 
 beforeEach(async () => {
-  await fs.writeFile(TEST_DB_PATH, '[]', 'utf-8')
+  DB_PATH = await createTempDb()
+  process.env.DB_PATH = DB_PATH
 })
 
 test('retrieves a transaction by ID', async () => {
   const input = 'accountName=test,amount=75.00,date=2025-07-11'
   const id = await addTransaction(input)
-
   const result = await getTransaction(id)
 
   expect(result).toContain(`Transaction ${id}`)
@@ -28,8 +27,8 @@ test('throws error for unknown transaction ID', async () => {
 
 afterAll(async () => {
   try {
-    await fs.unlink(TEST_DB_PATH)
+    await fs.unlink(DB_PATH)
   } catch {
-    // - ignore if file doesn't exist
+    // no file to delete
   }
 })

--- a/src/tests/setUpTestDb.ts
+++ b/src/tests/setUpTestDb.ts
@@ -1,0 +1,11 @@
+// test/setupTestDb.ts
+import path from 'path'
+import os from 'os'
+import fs from 'fs/promises'
+
+export async function createTempDb(): Promise<string> {
+  const tempDir = path.join(os.tmpdir(), `tx-test-${Date.now()}-${Math.random()}.json`)
+  await fs.writeFile(tempDir, '[]', 'utf-8')
+  return tempDir
+}
+

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,7 +17,6 @@ export function parseKeyValueArgs(input: string): Record<string, string> {
 export function isValidDate(dateStr: string): boolean {
   const regex = /^\d{4}-\d{2}-\d{2}$/
   if (!regex.test(dateStr)) return false
-
   const date = new Date(dateStr)
   return !isNaN(date.getTime()) && date.toISOString().startsWith(dateStr)
 }

--- a/transactions.json
+++ b/transactions.json
@@ -1,8 +1,0 @@
-[
-  {
-    "id": "815241c9-bf1b-4c50-9e36-adb32d260ba9",
-    "accountName": "checking",
-    "amount": 150,
-    "date": "2025-07-10"
-  }
-]


### PR DESCRIPTION
# Description
Jest tests missing unique temp database path for each set of tests. 
- Added createTempDb method called at the top of each test
- Test paths passed to file read/write functions in store.js via process.env.DB_PATH.

Fixes # CLI-001.jest.refactor

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)



